### PR TITLE
Add coercion argument to as-tensor

### DIFF
--- a/src/base/interop.lisp
+++ b/src/base/interop.lisp
@@ -1,34 +1,40 @@
 ;;; Interop
-;;; Functions to convert between Matlisp tensors and CL arrays
+;;; Functions to convert between Matlisp tensors and CL arrays/lists.
 
 (in-package #:matlisp)
 
-(defgeneric as-tensor (object)
-  (:documentation "Returns OBJECT as a Matlisp tensor type. May share storage or copy."))
+(defgeneric as-tensor (object &optional field-type)
+  (:documentation "Returns OBJECT as a Matlisp tensor type. May share storage or copy. The field-type is coerced to FIELD-TYPE, if it is non-NIL."))
 
-(defmethod as-tensor ((object tensor))
-  "If already a tensor then just return"
-  object)
+(defmethod as-tensor ((object tensor) &optional field-type)
+  "If already a tensor then just return."
+  (if (null field-type)
+      object
+      (copy object (tensor field-type))))
 
-(defmethod as-tensor ((object simple-vector))
+(defmethod as-tensor ((object simple-vector) &optional field-type)
   "Simple vectors can be used as store for a tensor. 
    The resulting tensor will share storage with the vector."
-  (make-instance (tensor (array-element-type object)) 
+  (make-instance (tensor (or field-type t))
                  :dimensions  (coerce (array-dimensions object) '(simple-array index-type (*)))
                  :store object))
 
-(defmethod as-tensor ((object array))
-  "Convert array OBJECT to tensor by copying contents"
+(defmethod as-tensor ((object array) &optional field-type)
+  "Convert array OBJECT to tensor by copying contents."
   (copy object
-        (tensor (array-element-type object))))
+        (tensor (or field-type (array-element-type object)))))
 
+(defmethod as-tensor ((object list) &optional field-type)
+  "Convert list OBJECT to tensor by copying contents."
+  (copy object
+	(tensor (or field-type t))))
 ;;;
 
 (defgeneric as-array (object)
-  (:documentation "Returns OBJECT as a CL array type. May share storage or copy. "))
+  (:documentation "Returns OBJECT as a CL array type. May share storage or copy."))
 
 (defmethod as-array ((object array))
-  "If already an array, just return"
+  "If already an array, just return."
   object)
 
 (defmethod as-array ((object tensor))

--- a/src/reader/infix.lisp
+++ b/src/reader/infix.lisp
@@ -220,14 +220,12 @@
     (@ t:@) (⊗ t:⊗) (** t:expt)
     (+ t:+) (- t:-)
     (\\ t::b\\) (/ t:/) (./ t:./)
-    (= t:=) (.= t:=)     ;;Not yet implemented.
-    (transpose t:transpose) (ctranspose t:ctranspose)))
-
-;; ("sum" t:sum) ("xlogx" t:xlogx) ("realpart" t:realpart) ("imagpart" t:imagpart)
-;; ("sqrt" t:sqrt) ("sin" t:sin) ("cos" t:cos) ("tan" t:tan) ("asin" t:asin) ("acos" t:acos) ("atan" t:atan)
-;; ("exp" t:exp) ("log" t:log) ("expt" t:expt)
-;; ("sinh" t:sinh) ("cosh" t:cosh) ("tanh" t:tanh) ("asinh" t:asinh) ("acosh" t:acosh) ("atanh" t:atanh)
-
+    (transpose t:transpose) (ctranspose t:ctranspose) (ctranspose t:ctranspose)
+    ;; (= t:=) (.= t:=) ;; TODO
+    (sum t:sum) (xlogx t:xlogx) (realpart t:realpart) (imagpart t:imagpart)
+    (sqrt t:sqrt) (sin t:sin) (cos t:cos) (tan t:tan) (asin t:asin) (acos t:acos) (atan t:atan)
+    (exp t:exp) (log t:log) (expt t:expt)
+    (sinh t:sinh) (cosh t:cosh) (tanh t:tanh) (asinh t:asinh) (acosh t:acosh) (atanh t:atanh)))
 
 (defun op-overload (expr &aux (table *operator-assoc-table*))
   (maptree-eki #'(lambda (tree)


### PR DESCRIPTION
I think it would be useful if the `AS-TENSOR` methods can do coercion of a field type.

Trivial matters: I deleted `ARRAY-ELEMENT-TYPE` in `AS-TENSOR` for simple vector, as it is always `t`.